### PR TITLE
feat: Populate English translation keys for multiple modules

### DIFF
--- a/public/locales/en/funnelsAutomationPage.json
+++ b/public/locales/en/funnelsAutomationPage.json
@@ -1,1 +1,48 @@
-{}
+{
+  "header": {
+    "title": "Funnel Automation",
+    "subtitle": "Configure automated actions and triggers for your sales funnels."
+  },
+  "selector": {
+    "label": "Configure Automation For:"
+  },
+  "stats": {
+    "activeRules": {
+      "title": "Active Rules in Funnel"
+    },
+    "automatedActionsToday": {
+      "title": "Automated Actions Today"
+    },
+    "errorsToday": {
+      "title": "Errors Today",
+      "needsAttention": "Needs attention",
+      "allClear": "All clear"
+    }
+  },
+  "rules": {
+    "titlePrefix": "Automation Rules for '{{funnelName}}'",
+    "buttons": {
+      "addNewRule": "Add New Rule"
+    },
+    "ruleCard": {
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive"
+      },
+      "buttons": {
+        "deactivateTooltip": "Deactivate Rule",
+        "activateTooltip": "Activate Rule",
+        "editTooltip": "Edit Rule",
+        "deleteTooltip": "Delete Rule"
+      },
+      "triggerLabel": "Trigger:",
+      "actionsLabel": "Actions:",
+      "timesTriggeredLabel": "Times Triggered: {{count}}",
+      "errorsLabel": "Errors: {{count}}"
+    },
+    "emptyMessage": "No automation rules configured for this funnel yet."
+  },
+  "emptyState": {
+    "message": "Select a funnel to view its automation rules."
+  }
+}

--- a/public/locales/en/funnelsBuilderPage.json
+++ b/public/locales/en/funnelsBuilderPage.json
@@ -1,1 +1,39 @@
-{}
+{
+  "header": {
+    "title": "Funnel Builder",
+    "subtitle": "Visually design your automated marketing and sales funnels."
+  },
+  "elementsPanel": {
+    "title": "Funnel Elements",
+    "items": {
+      "formSubmitted": "Form Submitted",
+      "tagAddedTrigger": "Tag Added",
+      "sendEmail": "Send Email",
+      "addTagAction": "Add Tag",
+      "waitPeriod": "Wait Period",
+      "emailOpenedCondition": "Email Opened?"
+    }
+  },
+  "canvas": {
+    "defaultFunnelName": "New Untitled Funnel",
+    "buttons": {
+      "load": "Load",
+      "save": "Save Funnel",
+      "new": "New Funnel"
+    },
+    "emptyMessage": "Drag elements from the left panel to build your funnel."
+  },
+  "propertiesPanel": {
+    "title": "Properties",
+    "selectedLabel": "Selected:",
+    "typeLabel": "Type:",
+    "stepNameLabel": "Step Name",
+    "emailTemplateIdLabel": "Email Template ID",
+    "emailTemplateIdPlaceholder": "e.g., welcome_tpl_01",
+    "waitDurationLabel": "Wait Duration (days)",
+    "buttons": {
+      "removeStep": "Remove Step"
+    },
+    "emptyMessage": "Select a step on the canvas or drag a new element to see its properties."
+  }
+}

--- a/public/locales/en/funnelsPage.json
+++ b/public/locales/en/funnelsPage.json
@@ -1,1 +1,44 @@
-{}
+{
+  "header": {
+    "title": "Funnels Overview",
+    "subtitle": "Design, monitor, and optimize your sales and marketing funnels."
+  },
+  "overviewStats": {
+    "activeFunnels": {
+      "title": "Active Funnels"
+    },
+    "totalLeadsInFunnels": {
+      "title": "Total Leads in Funnels",
+      "change": "+50 this week"
+    },
+    "overallConversionRate": {
+      "title": "Overall Conversion Rate"
+    },
+    "revenueFromFunnels": {
+      "title": "Revenue from Funnels (USD)",
+      "change": "+$5k last month"
+    }
+  },
+  "navLinks": {
+    "builder": {
+      "title": "Funnel Builder",
+      "description": "Visually design and configure your multi-step funnels."
+    },
+    "progress": {
+      "title": "Funnel Progress",
+      "description": "Track lead progression and conversion rates through each funnel stage."
+    },
+    "automation": {
+      "title": "Funnel Automation",
+      "description": "Set up automated actions and triggers within your funnels."
+    }
+  },
+  "chart": {
+    "title": "Top Performing Funnels (by Conversion Rate)",
+    "label": {
+      "conversionRate": "% Conv.",
+      "revenue": "Revenue: ${{amount}}"
+    },
+    "emptyMessage": "No funnel performance data available yet."
+  }
+}

--- a/public/locales/en/funnelsProgressPage.json
+++ b/public/locales/en/funnelsProgressPage.json
@@ -1,1 +1,53 @@
-{}
+{
+  "header": {
+    "title": "Funnel Progress & Analytics",
+    "subtitle": "Track lead movement and conversion rates through your funnels."
+  },
+  "stats": {
+    "totalLeads": {
+      "title": "Total Leads in Funnel"
+    },
+    "convertedLeads": {
+      "title": "Converted Leads"
+    },
+    "conversionRate": {
+      "title": "Funnel Conv. Rate"
+    },
+    "avgTimeInFunnel": {
+      "title": "Avg. Time in Funnel",
+      "unit": "days"
+    }
+  },
+  "selector": {
+    "label": "Select Funnel:"
+  },
+  "stages": {
+    "titleSuffix": "- Stages",
+    "card": {
+      "leadsInStageLabel": "Leads in Stage",
+      "conversionToStageLabel": "Conv. to Stage: {{rate}}%",
+      "dropOffRateLabel": "Drop-off: {{rate}}%"
+    }
+  },
+  "leadsTable": {
+    "titlePrefix": "Leads in '{{funnelName}}'",
+    "buttons": {
+      "filterLeads": "Filter Leads"
+    },
+    "headers": {
+      "name": "Name",
+      "email": "Email",
+      "currentStage": "Current Stage",
+      "entryDate": "Entry Date",
+      "timeInStage": "Time in Stage",
+      "status": "Status"
+    },
+    "status": {
+      "progressing": "Progressing",
+      "stalled": "Stalled",
+      "converted": "Converted",
+      "dropped": "Dropped"
+    },
+    "emptyMessage": "No leads to display for this funnel."
+  }
+}

--- a/public/locales/en/gapAnalysisFormPage.json
+++ b/public/locales/en/gapAnalysisFormPage.json
@@ -1,1 +1,128 @@
-{}
+{
+  "form": {
+    "header": {
+      "title": "Business Gap Analysis",
+      "subtitle": "Step {{currentStep}} of {{totalSteps}} - Answer questions to get personalized insights",
+      "backButton": "Back"
+    },
+    "progressLabel": "Complete",
+    "parameters": {
+      "cardTitle": "Market Analysis Parameters",
+      "cardDescription": "Define the scope and focus of your gap analysis",
+      "analysisTitleLabel": "Analysis Title",
+      "analysisTitlePlaceholder": "E.g., Enterprise Software Market Analysis",
+      "industryLabel": "Industry",
+      "industryPlaceholder": "Select industry",
+      "industries": {
+        "technology": "Technology",
+        "finance": "Finance",
+        "healthcare": "Healthcare",
+        "retail": "Retail",
+        "manufacturing": "Manufacturing"
+      },
+      "analysisDescriptionLabel": "Analysis Description",
+      "analysisDescriptionPlaceholder": "Describe the purpose and goals of this gap analysis...",
+      "marketSizeLabel": "Market Size",
+      "marketSizePlaceholder": "Select market size",
+      "marketSizes": {
+        "small": "Small (< $1M)",
+        "medium": "Medium ($1M - $10M)",
+        "large": "Large ($10M - $100M)",
+        "enterprise": "Enterprise (> $100M)"
+      },
+      "geographyLabel": "Geographic Focus",
+      "geographyPlaceholder": "Select region",
+      "geographies": {
+        "northAmerica": "North America",
+        "europe": "Europe",
+        "asiaPacific": "Asia Pacific",
+        "latinAmerica": "Latin America",
+        "global": "Global"
+      },
+      "competitiveAnalysisLabel": "Competitive Analysis",
+      "primaryCompetitorLabel": "Primary Competitor",
+      "primaryCompetitorPlaceholder": "Competitor name",
+      "secondaryCompetitorLabel": "Secondary Competitor",
+      "secondaryCompetitorPlaceholder": "Competitor name",
+      "analysisOptionsLabel": "Analysis Options",
+      "deepScanLabel": "Deep Market Scan",
+      "deepScanDescription": "Perform an extensive analysis of market trends and patterns",
+      "aiRecommendationsLabel": "AI Recommendations",
+      "aiRecommendationsDescription": "Include AI-powered strategic recommendations",
+      "generateLetterLabel": "Generate Sales Letter",
+      "generateLetterDescription": "Automatically create a sales letter based on findings",
+      "buttons": {
+        "saveDraft": "Save Draft",
+        "runAnalysis": "Run Analysis"
+      }
+    },
+    "questions": {
+      "cardDescription": "Please answer the following questions about your business",
+      "requiredIndicator": "*",
+      "scaleLabels": {
+        "poor": "Poor",
+        "excellent": "Excellent"
+      },
+      "placeholders": {
+        "number": "Enter number",
+        "text": "Enter your response"
+      },
+      "booleanYesLabel": "Yes"
+    },
+    "navigation": {
+      "previous": "Previous",
+      "next": "Next",
+      "completeAnalysis": "Complete Analysis",
+      "loading": "Loading..."
+    }
+  },
+  "results": {
+    "header": {
+      "backToDashboard": "Back to Dashboard",
+      "assessmentComplete": "Assessment Complete",
+      "processedMessage": "Your business analysis has been processed"
+    },
+    "overview": {
+      "overallScoreTitle": "Overall Score",
+      "priorityAreasTitle": "Priority Areas",
+      "improvementPotentialTitle": "Improvement Potential",
+      "highPotential": "High Potential",
+      "growthOpportunitiesMessage": "Significant growth opportunities identified"
+    },
+    "categoryBreakdown": {
+      "title": "Category Breakdown",
+      "description": "Detailed analysis across business dimensions"
+    },
+    "salesLetter": {
+      "title": "Personalized Sales Letter",
+      "description": "AI-generated based on your assessment results",
+      "buttons": {
+        "generate": "Generate Letter",
+        "regenerate": "Regenerate Letter",
+        "download": "Download",
+        "send": "Send Letter",
+        "generating": "Generating..."
+      },
+      "generationInfo": {
+        "generatedAt": "Generated {{datetime}}",
+        "justNow": "just now",
+        "regenerations": "{{count}} regenerations"
+      },
+      "readyToGenerate": {
+        "title": "Ready to Generate",
+        "description": "Click "Generate Letter" to create a personalized sales letter based on your assessment"
+      }
+    },
+    "recommendations": {
+      "title": "Strategic Recommendations",
+      "description": "Key areas for improvement based on your assessment",
+      "focusMessage": "Focus on improving your {{area}} to drive better business results and competitive advantage"
+    },
+    "actions": {
+      "startNewAssessment": "Start New Assessment",
+      "exportResults": "Export Results"
+    },
+    "errorSubmitting": "Error submitting analysis",
+    "errorGeneratingLetter": "Error generating letter"
+  }
+}

--- a/public/locales/en/gapAnalysisLettersPage.json
+++ b/public/locales/en/gapAnalysisLettersPage.json
@@ -1,1 +1,39 @@
-{}
+{
+  "header": {
+    "title": "Gap Analysis Letters",
+    "subtitle": "Manage and review AI-generated sales letters from your gap analyses.",
+    "buttons": {
+      "createNew": "Create New Letter"
+    }
+  },
+  "error": {
+    "fetchTitle": "Error Fetching Letters",
+    "unknown": "An unknown error occurred while trying to fetch letters.",
+    "tryAgainButton": "Try Again"
+  },
+  "emptyState": {
+    "title": "No Sales Letters Found",
+    "description": "Generate sales letters from your gap analysis results to see them here."
+  },
+  "letterCard": {
+    "subjectLabel": "Subject",
+    "recipientLabel": "Recipient",
+    "companyLabel": "Company",
+    "idLabel": "ID",
+    "createdLabel": "Created",
+    "buttons": {
+      "preview": "Preview"
+    },
+    "status": {
+      "draft": "Draft",
+      "sent": "Sent",
+      "archived": "Archived"
+    }
+  },
+  "previewDialog": {
+    "subjectPrefix": "Subject",
+    "buttons": {
+      "close": "Close"
+    }
+  }
+}

--- a/public/locales/en/gapAnalysisResultsPage.json
+++ b/public/locales/en/gapAnalysisResultsPage.json
@@ -1,1 +1,51 @@
-{}
+{
+  "header": {
+    "title": "Gap Analysis Results",
+    "subtitle": "Review the findings and recommendations from your gap analysis.",
+    "buttons": {
+      "export": "Export Results"
+    }
+  },
+  "error": {
+    "loadTitle": "Error Loading Results",
+    "unknown": "An unknown error occurred while trying to fetch results.",
+    "tryAgainButton": "Try Again"
+  },
+  "noResults": {
+    "title": "No Gap Analysis Results",
+    "description": "Complete a gap analysis to see your results here."
+  },
+  "summary": {
+    "totalGaps": "Total Gaps Identified",
+    "avgSeverity": "Average Severity",
+    "readinessScore": "Overall Readiness Score",
+    "keyAreas": "Key Areas for Improvement"
+  },
+  "charts": {
+    "severityDistribution": "Severity Distribution",
+    "areaDistribution": "Area Distribution",
+    "noData": "No data available for chart.",
+    "areaPlaceholder": "Area distribution chart will be displayed here."
+  },
+  "detailedResults": {
+    "title": "Detailed Gap Analysis",
+    "description": "Breakdown of identified gaps, severity, and recommendations.",
+    "headers": {
+      "area": "Area",
+      "gapDescription": "Gap Description",
+      "severity": "Severity",
+      "recommendations": "Recommendations",
+      "responsibleTeam": "Responsible Team"
+    },
+    "noDetailedResults": "No detailed gap results to display."
+  },
+  "severity": {
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low"
+  },
+  "common": {
+    "none": "None",
+    "notAssigned": "Not Assigned"
+  }
+}

--- a/public/locales/en/reviewsBoosterPage.json
+++ b/public/locales/en/reviewsBoosterPage.json
@@ -1,1 +1,66 @@
-{}
+{
+  "header": {
+    "title": "Review Booster",
+    "subtitle": "Implement strategies and campaigns to proactively increase positive reviews."
+  },
+  "stats": {
+    "activeCampaigns": {
+      "title": "Active Booster Campaigns"
+    },
+    "reviewsFromBooster": {
+      "title": "Reviews from Booster"
+    },
+    "avgRatingFromBooster": {
+      "title": "Avg. Rating (Booster)",
+      "unit": "/ 5"
+    }
+  },
+  "strategies": {
+    "title": "Booster Strategies",
+    "emailSequence": {
+      "name": "Post-Purchase Email Sequence",
+      "description": "Automatically send review requests via email a few days after a customer makes a purchase.",
+      "actionText": "Configure Sequence"
+    },
+    "smsCampaign": {
+      "name": "Targeted SMS Blasts",
+      "description": "Send review links via SMS to specific customer segments who recently had positive interactions.",
+      "actionText": "Launch SMS Campaign"
+    },
+    "qrGenerator": {
+      "name": "In-Store QR Code",
+      "description": "Generate unique QR codes for print materials at physical locations to encourage on-the-spot reviews.",
+      "actionText": "Generate QR Code"
+    },
+    "socialContest": {
+      "name": "Social Media Review Contest",
+      "description": "Run a contest on social media to incentivize customers to leave reviews.",
+      "actionText": "Setup Contest"
+    }
+  },
+  "campaignsTable": {
+    "title": "Active & Recent Campaigns",
+    "headers": {
+      "campaignName": "Campaign Name",
+      "strategy": "Strategy",
+      "startDate": "Start Date",
+      "status": "Status",
+      "reviewsGenerated": "Reviews Gen.",
+      "avgRating": "Avg. Rating",
+      "actions": "Actions"
+    },
+    "body": {
+      "noAvgRating": "-",
+      "buttons": {
+        "manageCampaignTooltip": "Manage Campaign"
+      }
+    },
+    "status": {
+      "active": "Active",
+      "paused": "Paused",
+      "completed": "Completed",
+      "draft": "Draft"
+    },
+    "emptyMessage": "No active review booster campaigns."
+  }
+}

--- a/public/locales/en/reviewsMonitoringPage.json
+++ b/public/locales/en/reviewsMonitoringPage.json
@@ -1,1 +1,70 @@
-{}
+{
+  "header": {
+    "title": "Review Monitoring",
+    "subtitle": "Track and respond to customer reviews from various platforms."
+  },
+  "stats": {
+    "newReviewsToday": {
+      "title": "New Reviews Today"
+    },
+    "pendingReply": {
+      "title": "Pending Reply"
+    },
+    "overallSentiment": {
+      "title": "Overall Sentiment",
+      "positiveSuffix": "% Positive"
+    }
+  },
+  "filters": {
+    "platforms": {
+      "all": "All Platforms",
+      "google": "Google",
+      "trustpilot": "Trustpilot",
+      "facebook": "Facebook"
+    },
+    "ratings": {
+      "all": "All Ratings",
+      "5stars": "5 Stars",
+      "4stars": "4 Stars",
+      "3stars": "3 Stars",
+      "2stars": "2 Stars",
+      "1star": "1 Star"
+    },
+    "statuses": {
+      "all": "All Statuses",
+      "new": "New",
+      "viewed": "Viewed",
+      "replied": "Replied",
+      "pendingReply": "Pending Reply"
+    },
+    "buttons": {
+      "apply": "Apply Filters"
+    }
+  },
+  "reviewCard": {
+    "onPlatform": "on {{platform}}",
+    "ratingOutOfFive": "({{rating}}/5)",
+    "yourReplyLabel": "Your Reply:",
+    "statusLabel": "Status: {{status}}",
+    "links": {
+      "viewOriginal": "View Original"
+    },
+    "buttons": {
+      "reply": "Reply"
+    }
+  },
+  "sentiment": {
+    "positive": "Positive",
+    "neutral": "Neutral",
+    "negative": "Negative"
+  },
+  "status": {
+    "new": "New",
+    "viewed": "Viewed",
+    "replied": "Replied",
+    "pendingReply": "Pending Reply"
+  },
+  "reviewsList": {
+    "emptyMessage": "No reviews to display."
+  }
+}

--- a/public/locales/en/reviewsRequestsPage.json
+++ b/public/locales/en/reviewsRequestsPage.json
@@ -1,1 +1,47 @@
-{}
+{
+  "header": {
+    "title": "Review Requests",
+    "subtitle": "Manage and track review invitations sent to customers."
+  },
+  "stats": {
+    "sentToday": {
+      "title": "Requests Sent Today"
+    },
+    "openRate": {
+      "title": "Est. Open Rate"
+    },
+    "reviewsFromRequests": {
+      "title": "Reviews from Requests"
+    }
+  },
+  "buttons": {
+    "filterRequests": "Filter Requests",
+    "sendNewRequest": "Send New Request"
+  },
+  "table": {
+    "headers": {
+      "dateSent": "Date Sent",
+      "recipient": "Recipient",
+      "platform": "Platform",
+      "campaign": "Campaign",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "body": {
+      "noCampaign": "-",
+      "buttons": {
+        "resendRequestTooltip": "Resend Request",
+        "viewDetailsTooltip": "View Details"
+      }
+    },
+    "emptyMessage": "No review requests found."
+  },
+  "status": {
+    "sent": "Sent",
+    "opened": "Opened",
+    "clicked": "Clicked",
+    "reviewed": "Reviewed",
+    "failed": "Failed",
+    "bounced": "Bounced"
+  }
+}

--- a/public/locales/en/vslPage.json
+++ b/public/locales/en/vslPage.json
@@ -1,1 +1,34 @@
-{}
+{
+  "header": {
+    "title": "VSL Management",
+    "subtitle": "Create, manage, and track your Video Sales Letter pages."
+  },
+  "stats": {
+    "totalVSLPages": {
+      "title": "Total VSL Pages"
+    },
+    "activeVSLs": {
+      "title": "Active VSLs"
+    },
+    "totalViews": {
+      "title": "Total Views"
+    },
+    "overallConversionRate": {
+      "title": "Overall VSL Conv. Rate"
+    }
+  },
+  "navLinks": {
+    "templates": {
+      "title": "VSL Templates",
+      "description": "Browse, manage, and create new VSL templates."
+    },
+    "myPages": {
+      "title": "My VSL Pages",
+      "description": "View, edit, and manage your created VSL pages."
+    },
+    "tracking": {
+      "title": "Performance Tracking",
+      "description": "Analyze views, engagement, and conversions for your VSLs."
+    }
+  }
+}

--- a/public/locales/en/vslPagesPage.json
+++ b/public/locales/en/vslPagesPage.json
@@ -1,1 +1,44 @@
-{}
+{
+  "header": {
+    "title": "My VSL Pages",
+    "subtitle": {
+      "loading": "Loading your VSL pages...",
+      "default": "Manage your created Video Sales Letters.",
+      "error": "Error"
+    }
+  },
+  "buttons": {
+    "createNewVSLPage": "Create New VSL Page",
+    "tryAgain": "Try Again"
+  },
+  "error": {
+    "loadFailedTitle": "Could not load VSL pages"
+  },
+  "emptyState": {
+    "title": "No VSL Pages Found",
+    "description": "Get started by creating a new VSL page from a template."
+  },
+  "table": {
+    "headers": {
+      "pageTitle": "Page Title",
+      "template": "Template",
+      "status": "Status",
+      "views": "Views",
+      "conversions": "Conversions",
+      "convRate": "Conv. Rate",
+      "created": "Created",
+      "actions": "Actions"
+    },
+    "actions": {
+      "viewLiveTooltip": "View Live Page",
+      "editTooltip": "Edit Page",
+      "statsTooltip": "View Stats",
+      "deleteTooltip": "Delete Page"
+    }
+  },
+  "status": {
+    "draft": "Draft",
+    "published": "Published",
+    "archived": "Archived"
+  }
+}

--- a/public/locales/en/vslTemplatesPage.json
+++ b/public/locales/en/vslTemplatesPage.json
@@ -1,1 +1,23 @@
-{}
+{
+  "header": {
+    "title": "VSL Templates",
+    "subtitle": {
+      "loading": "Loading available VSL templates...",
+      "default": "Browse, manage, and create new Video Sales Letter templates.",
+      "error": "Error"
+    }
+  },
+  "buttons": {
+    "createNewTemplate": "Create New Template",
+    "useTemplate": "Use Template",
+    "preview": "Preview",
+    "tryAgain": "Try Again"
+  },
+  "error": {
+    "loadFailedTitle": "Could not load VSL templates"
+  },
+  "emptyState": {
+    "title": "No VSL Templates Found",
+    "description": "Get started by creating your first VSL template."
+  }
+}

--- a/public/locales/en/vslTrackingPage.json
+++ b/public/locales/en/vslTrackingPage.json
@@ -1,1 +1,58 @@
-{}
+{
+  "header": {
+    "title": "VSL Performance Tracking",
+    "subtitle": {
+      "loading": "Loading VSL performance data...",
+      "default": "Analyze views, engagement, and conversions for your VSLs.",
+      "error": "Error"
+    }
+  },
+  "filters": {
+    "vslPageLabel": "VSL Page:",
+    "vslPagePlaceholder": "Select VSL Page",
+    "vslPageAll": "All VSL Pages",
+    "periodLabel": "Period:",
+    "periodPlaceholder": "Select Period",
+    "periods": {
+      "last7days": "Last 7 Days",
+      "last30days": "Last 30 Days",
+      "last3months": "Last 3 Months",
+      "allTime": "All Time"
+    }
+  },
+  "stats": {
+    "totalViews": "Total Views",
+    "totalLeads": "Total Leads",
+    "conversionRate": "Conversion Rate",
+    "avgWatchTime": "Avg. Watch Time"
+  },
+  "chart": {
+    "titlePrefix": "Performance Over Time for",
+    "defaultTitleSuffix": "Selected VSL",
+    "labels": {
+      "views": "Views",
+      "leads": "Leads",
+      "convRate": "Conv. Rate (%)"
+    },
+    "yAxis": {
+      "leftLabel": "Views/Leads",
+      "rightLabel": "Conv. Rate (%)"
+    }
+  },
+  "table": {
+    "title": "Performance by VSL Page",
+    "headers": {
+      "vslTitle": "VSL Title",
+      "views": "Views",
+      "leads": "Leads",
+      "convRate": "Conv. Rate (%)"
+    }
+  },
+  "error": {
+    "loadFailedTitle": "Could not load VSL tracking data",
+    "tryAgainButton": "Try Again"
+  },
+  "emptyState": {
+    "noData": "No VSL tracking data available for the selected filters."
+  }
+}


### PR DESCRIPTION
This commit continues the i18n translation task by populating English (en) locale files with translation keys for several application modules.

Changes include:

1.  **New Translation Files Created (Recap from previous relevant commit):** All 23 new JSON translation files for both `en` and `fr` locales were established.

2.  **English Keys Added For:**
    -   Re-engagement (4 files)
    -   Referrals (4 files)
    -   Reviews (3 files)
    -   Funnels (4 files)
    -   Gap Analysis (3 files)
    -   VSL (4 files)

    This accounts for 22 out of the 23 identified new locale files. Keys were derived from the content of their corresponding page components.

**Remaining for English Keys:**
-   `public/locales/en/leadResponseRulesPage.json` still needs to be populated.

**Next Major Steps in the i18n Plan:**
-   Complete the English keys for `leadResponseRulesPage.json`.
-   Translate all English keys into French for all 23 new files.
-   Update the i18n configuration (`src/i18n/config.ts`) with new namespaces.
-   Implement `useTranslation` hooks in all relevant page and component files.
-   Thoroughly test all translations and functionality.
-   Update any relevant documentation.